### PR TITLE
modify nginx config to serve the drs frontend

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -44,6 +44,11 @@ upstream drs-api-upstream {
     keepalive 64;
 }
 
+upstream drs-frontend-upstream {
+    server da6.local:3173;
+    keepalive 64;
+}
+
 server {
     listen 443 ssl http2;
     server_name worldofcode.org www.worldofcode.org;
@@ -120,6 +125,17 @@ server {
         proxy_http_version 1.1;
         proxy_buffering off;
     }
+    location = /drs-api { return 301 /drs-api/; }
+
+    location /drs/ {
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_pass http://drs-frontend-upstream;
+    }
+    location = /drs { return 301 /drs/; }
 
     # Static server
     location / {


### PR DESCRIPTION
This adds a config to nginx to serve the frontend for DRS on port 3173 on da6 server.