### PR TITLE
Add DRS to main nav

### DIFF
--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -81,6 +81,13 @@ export const navItems: NavItem[] = [
     external: true
   },
   {
+    title: 'DRS',
+    href: '/drs',
+    icon: 'i-material-symbols:security',
+    description: 'DRS-OSS — LLM pull-request bug-risk scoring',
+    external: true
+  },
+  {
     title: 'Lookup',
     href: '/lookup',
     icon: 'i-material-symbols:category-search',


### PR DESCRIPTION
Adds a **DRS** item to the top navigation bar, linking to `/drs` (the DRS-OSS pull-request bug-risk scoring app, served separately via nginx → da6).

Flagged `external: true` like the existing **Docs** entry so the navbar does a real browser navigation rather than an in-app react-router route (DRS is a separate app, not an SPA route).

- Label: `DRS`
- Icon: `i-material-symbols:security`
- Opens in a new tab (matches Docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)