### PR TITLE
Disable ssl_password_file in nginx config

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -78,7 +78,7 @@ server {
     # SSL certificate files
     ssl_certificate /etc/nginx/ssl/worldofcode.org.crt;      # or Let's Encrypt path
     ssl_certificate_key /etc/nginx/ssl/worldofcode.org.key;  # or Let's Encrypt path
-    ssl_password_file /etc/nginx/ssl/worldofcode.org.pass; # if using a password-protected key
+    #ssl_password_file /etc/nginx/ssl/worldofcode.org.pass; # if using a password-protected key
     
     # SSL configuration (security best practices)
     ssl_protocols TLSv1.2 TLSv1.3;


### PR DESCRIPTION
Origin cert is now a Cloudflare Origin CA cert with an unencrypted key, so `ssl_password_file` is unneeded and would break startup. Comments it out to match the live config on da2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)