### PR TITLE
Cite arXiv:2606.28120 on Impact Explorer; refresh WoC news

### DIFF
--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -128,7 +128,21 @@ export const navItems: NavItem[] = [
 export const updateBanner = {
   text: 'V2604 now available (March 2026 data, 5.9B commits). All servers on RHEL9.',
   linkHref: '/docs/#/updates.md',
-  linkText: 'Details'
+  linkText: 'Details',
+  highlights: [
+    {
+      icon: 'i-material-symbols:bolt-outline',
+      text: 'Near-real-time data gathering — an hourly streaming pipeline (GH Archive → LMDB) is replacing batch dumps (gather_new).'
+    },
+    {
+      icon: 'i-material-symbols:layers-outline',
+      text: 'A layered object store brings incremental, append-only updates without full rebuilds (lookup).'
+    },
+    {
+      icon: 'i-material-symbols:speed-outline',
+      text: 'libgit2-woc: faster C commit-diff extraction over the layered store (~7–8× vs. the previous tooling).'
+    }
+  ]
 };
 
 export const useCaseItems: HomePageItem[] = [

--- a/frontend/src/pages/impact/index.tsx
+++ b/frontend/src/pages/impact/index.tsx
@@ -163,11 +163,22 @@ function Ticker({ value, label, sub, icon }: { value: number; label: string; sub
 function Hero({ s }: { s: Summary }) {
   return (
     <div className="z-1 flex flex-col items-center gap-5 pt-10">
-      <div className="dark:bg-slate-8/70 flex items-center gap-2 rounded-full bg-slate-100/70 px-4 py-1 text-xs backdrop-blur-sm">
-        <span className="i-material-symbols:hub-outline text-primary/60" />
-        <span className="text-primary/70 font-medium">
-          Cross-corpus graph · {fmt(s.stats.edges)} typed edges · watermark {s.watermark}
-        </span>
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <div className="dark:bg-slate-8/70 flex items-center gap-2 rounded-full bg-slate-100/70 px-4 py-1 text-xs backdrop-blur-sm">
+          <span className="i-material-symbols:hub-outline text-primary/60" />
+          <span className="text-primary/70 font-medium">
+            Cross-corpus graph · {fmt(s.stats.edges)} typed edges · watermark {s.watermark}
+          </span>
+        </div>
+        <a
+          href="https://arxiv.org/abs/2606.28120"
+          target="_blank"
+          className="dark:bg-slate-8/70 dark:hover:bg-slate-700/70 flex items-center gap-1.5 rounded-full bg-slate-100/70 px-4 py-1 text-xs backdrop-blur-sm transition-colors hover:bg-slate-200/70"
+        >
+          <span className="i-simple-icons:arxiv text-primary/60" />
+          <span className="text-primary/70 font-medium">arXiv:2606.28120</span>
+          <span className="i-material-symbols:open-in-new text-primary/40" />
+        </a>
       </div>
       <h1 className="gradient-text text-center text-5xl font-bold md:text-6xl">Impact Explorer</h1>
       <p className="text-primary/60 max-w-2xl text-center text-lg">
@@ -726,6 +737,17 @@ export default function ImpactPage() {
           <p className="text-primary/40 mt-2 max-w-2xl px-4 text-center text-xs">
             Built from the World of Code cross-corpus graph ({fmt(summary.stats.edges)} typed edges,
             watermark {summary.watermark}) joining projects, papers, authors, and packages.
+          </p>
+          <p className="text-primary/50 mt-1 max-w-2xl px-4 text-center text-xs">
+            Data &amp; methodology:{' '}
+            <a
+              href="https://arxiv.org/abs/2606.28120"
+              target="_blank"
+              className="text-primary/70 font-medium underline underline-offset-2 hover:text-primary"
+            >
+              arXiv:2606.28120
+            </a>
+            {' '}— please cite this paper when using the data.
           </p>
         </Section>
       </div>

--- a/frontend/src/pages/index/index.tsx
+++ b/frontend/src/pages/index/index.tsx
@@ -148,12 +148,27 @@ function HomePageCard({ ...props }: HomePageItem) {
 
 function UpdateBanner() {
   return (
-    <div className="z-1 dark:bg-slate-8/80 flex items-center gap-3 rounded-lg bg-slate-100/80 px-4 py-2 text-sm backdrop-blur-sm">
-      <span className="i-fluent-emoji-flat:warning text-lg" />
-      <span className="text-primary/70">{updateBanner.text}</span>
-      <a href={updateBanner.linkHref} className="text-primary/90 font-medium underline underline-offset-2">
-        {updateBanner.linkText}
-      </a>
+    <div className="z-1 flex flex-col items-center gap-2">
+      <div className="dark:bg-slate-8/80 flex items-center gap-3 rounded-lg bg-slate-100/80 px-4 py-2 text-sm backdrop-blur-sm">
+        <span className="i-fluent-emoji-flat:warning text-lg" />
+        <span className="text-primary/70">{updateBanner.text}</span>
+        <a href={updateBanner.linkHref} className="text-primary/90 font-medium underline underline-offset-2">
+          {updateBanner.linkText}
+        </a>
+      </div>
+      {updateBanner.highlights?.length > 0 && (
+        <div className="flex max-w-3xl flex-wrap items-center justify-center gap-2">
+          {updateBanner.highlights.map((h) => (
+            <span
+              key={h.text}
+              className="dark:bg-slate-8/50 text-primary/60 flex items-center gap-1.5 rounded-full bg-slate-100/60 px-3 py-1 text-xs backdrop-blur-sm"
+            >
+              <span className={cn('text-primary/40 shrink-0', h.icon)} />
+              {h.text}
+            </span>
+          ))}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Follow-up to #18.

- **Impact Explorer** now cites the data-source paper **arXiv:2606.28120** — a linked chip in the hero and a "please cite this paper when using the data" line in the footer.
- **Homepage news** banner gains three current-development highlights under the V2604 headline:
  - Near-real-time data gathering — hourly streaming pipeline (GH Archive → LMDB) replacing batch dumps (`gather_new`).
  - Layered object store with incremental, append-only updates (`lookup`).
  - `libgit2-woc`: faster C commit-diff extraction over the layered store (~7–8×).

Built clean via `build_docker.sh`; arXiv id and news strings verified in the bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)