### PR TITLE
Explore: pass ?limit= to bound payloads on high-degree keys

### DIFF
--- a/frontend/src/api/lookup.ts
+++ b/frontend/src/api/lookup.ts
@@ -113,10 +113,12 @@ export const getValue = async <T>(map: string, key: string): Promise<T> => {
 
 export const getValues = async <T>(
   map: string,
-  keys: string[]
+  keys: string[],
+  limit?: number
 ): Promise<Record<string, T>> => {
   const params = new URLSearchParams();
   keys.forEach((k) => params.append('q', k));
+  if (limit && limit > 0) params.append('limit', String(limit));
   const resp = await request<Record<string, T>>(
     `/lookup/map/${map}`,
     'GET',

--- a/frontend/src/pages/explore/index.tsx
+++ b/frontend/src/pages/explore/index.tsx
@@ -48,6 +48,8 @@ const MAX_NODES = 260;
 const MAX_EXPAND = 20;
 const FRONTIER_PER_SOURCE = 8; // per-source cap when expanding a whole frontier at once
 const BATCH_CHUNK = 40;        // keys per request (bounds GET URL length; chunks run in parallel)
+const FETCH_LIMIT = 50;        // server-side ?limit= — bounds payload for high-degree keys
+                               // (>= display caps, so nothing shown is starved)
 
 /* Session caches — each (map,key) lookup and each metadata doc is deterministic for a given
    watermark, so we fetch once and reuse. This is what keeps re-expansion / back-and-forth
@@ -58,7 +60,7 @@ async function fetchRel(map: string, key: string): Promise<string[]> {
   const ck = `${map} ${key}`;
   const hit = relCache.get(ck);
   if (hit) return hit;
-  const res = await getValues<unknown>(map, [key]);
+  const res = await getValues<unknown>(map, [key], FETCH_LIMIT);
   const vals = Array.from(new Set(normValues((res as Record<string, unknown>)[key])));
   relCache.set(ck, vals);
   return vals;
@@ -70,7 +72,7 @@ async function fetchRelBatch(map: string, keys: string[]): Promise<Map<string, s
   const chunks: string[][] = [];
   for (let i = 0; i < missing.length; i += BATCH_CHUNK) chunks.push(missing.slice(i, i + BATCH_CHUNK));
   await Promise.all(chunks.map(async (chunk) => {
-    const res = (await getValues<unknown>(map, chunk)) as Record<string, unknown>;
+    const res = (await getValues<unknown>(map, chunk, FETCH_LIMIT)) as Record<string, unknown>;
     for (const k of chunk) relCache.set(`${map} ${k}`, Array.from(new Set(normValues(res[k]))));
   }));
   const out = new Map<string, string[]>();
@@ -298,7 +300,11 @@ export default function ExplorePage() {
       if (!vals.length) { setNotice(`No ${rel.label.toLowerCase()} found for this ${node.type}.`); return; }
       const capped = vals.slice(0, MAX_EXPAND);
       for (const v of capped) { const nn = addNode(rel.to, v); if (nn) addEdge(node.id, nn.id, rel.id); }
-      if (vals.length > capped.length) setNotice(`Showing ${capped.length} of ${vals.length} ${rel.label.toLowerCase()} (capped for legibility).`);
+      if (vals.length > capped.length) {
+        // vals is bounded by the server ?limit=FETCH_LIMIT; a full page means "≥ that, more exist"
+        const total = vals.length >= FETCH_LIMIT ? `${FETCH_LIMIT}+` : `${vals.length}`;
+        setNotice(`Showing ${capped.length} of ${total} ${rel.label.toLowerCase()} (payload capped at ${FETCH_LIMIT}).`);
+      }
       kick(0.9);
     } catch {
       setNotice(`Could not load ${rel.label.toLowerCase()} — the ${node.type} may not be in this map.`);


### PR DESCRIPTION
Follow-up to #28 (backend `limit`). `getValues` now takes an optional `limit`; the explorer sends **`limit=50`** (`FETCH_LIMIT`, comfortably above its 20-per-expand / 8-per-frontier display caps) on every relation lookup and batched frontier fetch. A high-degree key like `P2A` of a huge project then transfers ~50 values instead of tens of thousands. The 'showing N of M' notice shows 'N of 50+' when the source cap is hit.

**Backward-safe:** FastAPI ignores the unknown query param on the not-yet-restarted backend (returns full results, client slices as before), so this can deploy independently; it starts bounding payloads once the #28 backend is restarted.