### PR TITLE
mozdemo: live /api/mozdemo/analyze router for arbitrary commits

### DIFF
--- a/backend/woc_backend/__main__.py
+++ b/backend/woc_backend/__main__.py
@@ -17,6 +17,7 @@ from .auth.routes import api as auth_api
 from .clickhouse.routes import api as clickhouse_api
 from .config import settings
 from .lookup.routes import api as lookup_api
+from .mozdemo.routes import api as mozdemo_api
 from .mongo.models import MongoAPI, MongoAuthor, MongoProject
 from .mongo.routes import api as mongo_api
 from .utils.cache import MemoryCache, RedisCache
@@ -123,6 +124,9 @@ app.include_router(
     clickhouse_api,
     prefix="/clickhouse",
     dependencies=[Depends(validate_token_nullable)],
+)
+app.include_router(
+    mozdemo_api, prefix="/mozdemo", dependencies=[Depends(validate_token_nullable)]
 )
 app.include_router(auth_api, prefix="/auth")
 

--- a/backend/woc_backend/mozdemo/engine.py
+++ b/backend/woc_backend/mozdemo/engine.py
@@ -1,0 +1,127 @@
+"""mozdemo query engine — Firefox backport commit -> three updatebot-scenario panels.
+
+Mirrors frontend/scripts/build-mozdemo-data.py (keep in sync). Reads WoC maps via the
+getValues CLI (the reliable path on da2; the HTTP map API 500s on compound bb2cf and
+python-woc's default profile can't locate the shard files). Bound to VER. Never fabricates.
+
+Both project attributions are computed: deforked (c2P, forks collapsed to one canonical
+project) and raw (c2p, every repository). Set env WOC_GETVALUES / MOZDEMO_VER to override.
+"""
+import os
+import re
+import subprocess
+import datetime
+
+GV = os.environ.get("WOC_GETVALUES", os.path.expanduser("~/lookup/getValues"))
+GV_HOME = os.path.dirname(os.path.dirname(GV))  # e.g. /home/audris (so root finds the profile)
+GV_CWD = os.path.dirname(GV)                     # e.g. /home/audris/lookup
+VER = os.environ.get("MOZDEMO_VER", "V2604")
+README = ("README.mozilla", "README.moz-ff-commit")  # vendoring bookkeeping, not source
+RAW_CAP = 80
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def gv(map_, key, ver=VER):
+    try:
+        out = subprocess.run(
+            [GV, map_, ver], input=key + "\n", capture_output=True, text=True,
+            timeout=90, cwd=GV_CWD, env={**os.environ, "HOME": GV_HOME},
+        ).stdout.strip()
+    except Exception:
+        return []
+    if not out:
+        return []
+    parts = [p.replace("\x00", "").strip() for p in out.split(";")]
+    return parts[1:] if parts and parts[0] == key else parts
+
+
+def _triples(f, n=3):
+    return [tuple(f[i:i + n]) for i in range(0, len(f) - n + 1, n)]
+
+
+def _ts(s):
+    s = s.strip()
+    return datetime.datetime.utcfromtimestamp(int(s)) if s.isdigit() else None
+
+
+def _commit_dt(commit):
+    f = gv("c2dat", commit)
+    return _ts(f[0]) if f else None
+
+
+def _projects(commit, deforked=True):
+    return {p for p in gv("c2P" if deforked else "c2p", commit) if p}
+
+
+def _attribution(commits):
+    dedf, raw = set(), set()
+    for c in commits:
+        dedf |= _projects(c, True)
+        raw |= _projects(c, False)
+    rl = sorted(raw)
+    return {"deforked": sorted(dedf), "deforked_count": len(dedf),
+            "raw": rl[:RAW_CAP], "raw_count": len(raw), "raw_truncated": len(raw) > RAW_CAP}
+
+
+LIBPIXMAN_NOTE = ("Still-exposed enumeration needs a fresh b2P (blob->project). b2P V..V2605 "
+                  "do not index these Nov-2023 blobs, so the never-fixed set can't be listed "
+                  "here yet - the near-real-time thrust builds exactly this map. Proven end to "
+                  "end on libpixman/CVE-2022-44638: 662 projects still carried the pre-fix blob.")
+
+
+def analyze(commit):
+    """Return {commit, commit_date, version, files:[...three panels...]} or raise ValueError."""
+    if not SHA_RE.match(commit):
+        raise ValueError("commit must be a 40-char lowercase hex sha1")
+    cdt = _commit_dt(commit)
+    cf = _triples(gv("c2fbb", commit))
+    files_src = [t for t in cf if not any(t[0].endswith(r) for r in README)]
+    files = []
+    for path, old, new in files_src:
+        variants = {}
+        for nb, fc, _ in _triples(gv("bb2cf", old)):
+            variants.setdefault(nb, {"new_blob": nb, "commits": set(), "dates": []})["commits"].add(fc)
+        for v in variants.values():
+            for fc in v["commits"]:
+                d = _commit_dt(fc)
+                if d:
+                    v["dates"].append(d)
+            v["proj"] = _attribution(v["commits"])
+
+        def vrec(v):
+            return {"new_blob": v["new_blob"] or None, "deleted": not v["new_blob"],
+                    "commits": len(v["commits"]), "proj": v["proj"],
+                    "first_date": min(v["dates"]).date().isoformat() if v["dates"] else None,
+                    "is_firefox": v["new_blob"] == new}
+        vlist = sorted((vrec(v) for v in variants.values()),
+                       key=lambda x: (x["proj"]["deforked_count"], x["proj"]["raw_count"], x["commits"]),
+                       reverse=True)
+
+        bf = gv("b2fa", new)
+        first = _ts(bf[0]) if bf else None
+        first_author = bf[1].strip() if len(bf) > 1 else None
+        ff = next((v for v in vlist if v["is_firefox"]), None)
+        first_downstream = ff["first_date"] if ff else None
+        gap_up = (cdt.date() - first.date()).days if (cdt and first) else None
+        gap_down = ((cdt.date() - datetime.date.fromisoformat(first_downstream)).days
+                    if (cdt and first_downstream) else None)
+        consensus = next((v for v in vlist if not v["deleted"] and not v["is_firefox"]), None)
+        all_c = {c for v in variants.values() for c in v["commits"]}
+        other_c = {c for v in variants.values() if v["new_blob"] and v["new_blob"] != new for c in v["commits"]}
+
+        files.append({
+            "path": path, "old_blob": old, "firefox_new_blob": new,
+            "panel_a": {"fix_first_appeared": first.isoformat() if first else None,
+                        "fix_first_author": first_author, "first_downstream_date": first_downstream,
+                        "gap_days_from_upstream": gap_up, "gap_days_from_first_downstream": gap_down,
+                        "variant_count": len(vlist), "variants": vlist},
+            "panel_b": {"known_fixed": _attribution(all_c), "still_exposed_available": False,
+                        "note": LIBPIXMAN_NOTE},
+            "panel_c": {"firefox_blob": new,
+                        "firefox_adopters": ff["proj"] if ff else _attribution(set()),
+                        "consensus_blob": consensus["new_blob"] if consensus else None,
+                        "consensus_adopters": consensus["proj"] if consensus else _attribution(set()),
+                        "other_variant_adopters": _attribution(other_c)},
+        })
+    return {"commit": commit, "commit_date": cdt.isoformat() if cdt else None,
+            "version": VER, "files": files}

--- a/backend/woc_backend/mozdemo/routes.py
+++ b/backend/woc_backend/mozdemo/routes.py
@@ -1,0 +1,62 @@
+"""mozdemo live API — analyze an arbitrary Firefox backport commit.
+
+GET /mozdemo/analyze?commit=<40-hex sha1>  ->  the same three-panel structure the
+static worked examples use (see frontend/public/mozdemo-data). Results are memoised.
+Commit metadata (author + verbatim first message line) is read via python-woc.
+"""
+import re
+
+from fastapi import APIRouter, HTTPException, Request
+
+from ..models import WocResponse
+from .engine import analyze, VER
+
+api = APIRouter()
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _cache(request: Request):
+    return getattr(request.app.state, "lookup_cache", None)
+
+
+def _commit_meta(request: Request, commit: str):
+    """author + verbatim first message line via python-woc (labeled, not fabricated)."""
+    try:
+        woc = request.app.state.woc
+        tree, parent, author, committer, message = woc.show_content("commit", commit)
+        line = (message or "").split("\n")[0].strip()
+        m = re.search(r"Bug\s+(\d+)", line)
+        return {"author": author[0] if isinstance(author, (list, tuple)) else author,
+                "message_line": line or None, "bug": m.group(1) if m else None}
+    except Exception:
+        return {"author": None, "message_line": None, "bug": None}
+
+
+@api.get("/analyze", response_model=WocResponse, response_model_exclude_none=True)
+def analyze_commit(request: Request, commit: str):
+    """Analyze a Firefox backport commit for the three updatebot scenarios."""
+    commit = commit.strip().lower()
+    if not SHA_RE.match(commit):
+        raise HTTPException(status_code=400, detail="commit must be a 40-char lowercase hex sha1")
+
+    cache = _cache(request)
+    ckey = f"mozdemo:{VER}:{commit}"
+    if cache is not None:
+        hit = cache.get(ckey)
+        if hit is not None:
+            return WocResponse(data=hit)
+
+    try:
+        data = analyze(commit)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"map lookup failed: {e}")
+
+    if not data.get("files"):
+        raise HTTPException(status_code=404, detail=f"{commit} touches no vendored source file we can trace")
+
+    data.update(_commit_meta(request, commit))
+    if cache is not None:
+        cache.put(ckey, data, ttl=3600)
+    return WocResponse(data=data)

--- a/frontend/src/pages/mozdemo/index.tsx
+++ b/frontend/src/pages/mozdemo/index.tsx
@@ -208,12 +208,25 @@ export default function MozDemoPage() {
       .catch(() => setErr(true));
   }, []);
 
+  const [live, setLive] = useState<Example | null>(null);
+  const [liveState, setLiveState] = useState<'idle' | 'loading' | 'error' | 'notfound' | 'unavailable'>('idle');
   const byCommit = useMemo(() => new Map((doc?.examples || []).map((e) => [e.commit, e])), [doc]);
-  const example = selected ? byCommit.get(selected) : undefined;
-  const submit = () => {
+  const example = selected ? (byCommit.get(selected) ?? (live && live.commit === selected ? live : undefined)) : undefined;
+
+  const submit = async () => {
     const c = commit.trim().toLowerCase();
-    if (byCommit.has(c)) setSelected(c);
-    else setSelected(c || null); // unknown → handled below as "not precomputed"
+    if (!c) return;
+    setLive(null);
+    if (byCommit.has(c)) { setSelected(c); setLiveState('idle'); return; }
+    if (!/^[0-9a-f]{40}$/.test(c)) { setSelected(c); setLiveState('error'); return; }
+    setSelected(c); setLiveState('loading');
+    try {
+      const r = await fetch(`/api/mozdemo/analyze?commit=${c}`);
+      if (r.status === 404) { setLiveState('notfound'); return; }
+      if (!r.ok) { setLiveState(r.status === 400 ? 'error' : 'unavailable'); return; }
+      const j = await r.json();
+      setLive(j.data as Example); setLiveState('idle');
+    } catch { setLiveState('unavailable'); }
   };
 
   return (
@@ -263,11 +276,15 @@ export default function MozDemoPage() {
         <div className="z-1 w-full">
           {err && <div className="rounded-md border-2 border-dashed border-slate-500 p-6 text-sm">Could not load the demo dataset.</div>}
           {!doc && !err && <div className="flex flex-col gap-3"><Skeleton className="h-24 w-full rounded-xl" /><Skeleton className="h-40 w-full rounded-xl" /></div>}
-          {doc && selected && !example && (
+          {liveState === 'loading' && !example && (
+            <div className="flex flex-col gap-3"><Skeleton className="h-24 w-full rounded-xl" /><Skeleton className="h-40 w-full rounded-xl" /></div>
+          )}
+          {doc && selected && !example && liveState !== 'loading' && (
             <div className="rounded-xl border border-amber-500/40 bg-amber-500/10 p-5 text-sm text-amber-800 dark:text-amber-300">
-              <b className="font-mono">{sha(selected, 16)}</b> isn't one of the precomputed examples. Live analysis of
-              arbitrary commits runs through the WoC API (coming online shortly). For now, click a worked example above —
-              they reproduce the batch prototype's numbers exactly against WoC {doc.version}.
+              {liveState === 'error' && <>“{selected}” is not a 40-character commit SHA-1. Paste a Firefox backport commit hash, or click a worked example.</>}
+              {liveState === 'notfound' && <><b className="font-mono">{sha(selected, 16)}</b> doesn't touch a vendored source file we can trace (or isn't in WoC {doc.version}).</>}
+              {liveState === 'unavailable' && <>Live analysis of arbitrary commits isn't reachable right now. The worked examples above run offline and reproduce the batch prototype exactly against WoC {doc.version}.</>}
+              {liveState === 'idle' && <><b className="font-mono">{sha(selected, 16)}</b> isn't a precomputed example — click one above.</>}
             </div>
           )}
           {example && (


### PR DESCRIPTION
Adds a `mozdemo` router to the FastAPI backend (`woc_backend/mozdemo`): `GET /mozdemo/analyze?commit=<40-hex>` returns the same three-panel structure the static worked examples use, with both project attributions (deforked + raw). The engine mirrors `frontend/scripts/build-mozdemo-data.py` and shells to `getValues` (HOME set so it resolves the profile when the backend runs as root); results memoised 1h; commit SHA strictly validated (no injection); commit author/message read verbatim via python-woc.

Frontend: submitting a non-precomputed commit calls the live endpoint and renders it, with graceful states (invalid SHA / untraceable / unavailable) so the page stays honest before the backend restart.

Engine validated on da2 — reproduces `REPORT.md` at V2604 (7 variants, 88/92-day gap, 4/66 firefox adopters deforked/raw, 15/88 known-fixed) and rejects injection. `py_compile` clean; frontend builds clean (10 routes).

**Deploy:** the static worked examples ship with a frontend rsync; the live route needs the root backend restarted onto `main`.