### PR TITLE
landing: floor authors + projects tickers to exact V2605 counts

### DIFF
--- a/frontend/src/pages/index/index.tsx
+++ b/frontend/src/pages/index/index.tsx
@@ -240,6 +240,7 @@ function WocLogoAndButtons() {
         <WocNumberTicker
           variant="a2c"
           subtitle="across all public repos"
+          floor={123705960}
           title={
             <div className="flex items-center gap-2">
               <span className="i-mdi:account-group" />
@@ -250,6 +251,7 @@ function WocLogoAndButtons() {
         <WocNumberTicker
           variant="p2c"
           subtitle="from every git forge"
+          floor={350683595}
           title={
             <div className="flex items-center gap-2">
               <span className="i-mdi:source-repository" />


### PR DESCRIPTION
Completes the V2605 landing tickers with isaac's exact distinct-key counts (from `aFull`/`pFull.V2605.s`):
- **authors** (raw, matches a2c ticker): **123,705,960**
- **projects** (raw, matches p2c ticker): **350,683,595**

Both pinned as floors (same auto-heal as the commit floor — authoritative V2605 now, reverts to live when da2's store catches up). Raw basis parallels the raw-author decision; deforked projects (283.6M) is a one-line switch if preferred. Built clean (10 routes).